### PR TITLE
feat: implement feature flags for tracking functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -175,6 +175,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.7.tgz",
       "integrity": "sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.23.5",
@@ -1142,6 +1143,7 @@
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
       "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/expect": "^29.7.0",
@@ -1807,6 +1809,7 @@
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.11.tgz",
       "integrity": "sha512-S2mHmYIVe13vrm6q4kN6fLYYAka15ALQki/vgDC3mIukEOx8WJlv0kQPM+d4w8Gp6u0uSdKND04IlTXBv0rwnQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
@@ -1869,7 +1872,8 @@
     "node_modules/@types/node": {
       "version": "20.4.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.4.tgz",
-      "integrity": "sha512-CukZhumInROvLq3+b5gLev+vgpsIqC2D0deQr/yS1WnxvmYLlJXZpaQrQiseMY+6xusl79E04UjWoqyr+t1/Ew=="
+      "integrity": "sha512-CukZhumInROvLq3+b5gLev+vgpsIqC2D0deQr/yS1WnxvmYLlJXZpaQrQiseMY+6xusl79E04UjWoqyr+t1/Ew==",
+      "peer": true
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -2054,6 +2058,7 @@
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
       "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2618,6 +2623,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001565",
         "electron-to-chromium": "^1.4.601",
@@ -3687,6 +3693,7 @@
       "version": "8.45.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.45.0.tgz",
       "integrity": "sha512-pd8KSxiQpdYRfYa9Wufvdoct3ZPQQuVuU5O6scNgMuOMYuxvH0IGaYK0wUFjo4UYYQQCUndlXiMbnxopwvvTiw==",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
@@ -3861,6 +3868,7 @@
       "version": "2.28.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.1.tgz",
       "integrity": "sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.6",
         "array.prototype.findlastindex": "^1.2.2",
@@ -5390,6 +5398,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -7393,6 +7402,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -7726,6 +7736,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7749,6 +7760,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -8925,6 +8937,7 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -9111,6 +9124,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/app/[lang]/(inicio)/sections/TrackingBar/index.tsx
+++ b/src/app/[lang]/(inicio)/sections/TrackingBar/index.tsx
@@ -3,6 +3,7 @@ import React, { FC } from 'react';
 import { LangInterface } from '@constans/interfaces/langInterface';
 
 import { useForm, useTracking } from '@hooks/index';
+import { flags } from '@src/lib/config/flags';
 
 interface TrackingBarProps extends LangInterface {
   showText?: boolean;
@@ -10,14 +11,12 @@ interface TrackingBarProps extends LangInterface {
   position?: 'absolute' | 'relative';
 }
 
-export const TrackingBar: FC<TrackingBarProps> = ({
+const TrackingBarInner: FC<TrackingBarProps> = ({
   lang,
   showText = true,
   sameWindow = false,
   position = 'absolute',
 }) => {
-  const enableTracking = process.env.NEXT_PUBLIC_ENABLED_MESSAGING_TRACKING;
-
   const [formValues, handleInputChange, reset] = useForm({
     trackingNumber: '' as string,
     trackingType: '' as string,
@@ -72,7 +71,7 @@ export const TrackingBar: FC<TrackingBarProps> = ({
               <option value="packaging">
                 {lang === 'es' ? 'Paquetería' : 'Courier'}
               </option>
-              {enableTracking === 'true' && (
+              {flags.messagingTrackingEnabled && (
                 <option value="messaging">
                   {lang === 'es' ? 'Mensajería' : 'Messaging'}
                 </option>
@@ -108,4 +107,10 @@ export const TrackingBar: FC<TrackingBarProps> = ({
       </form>
     </section>
   );
+};
+
+export const TrackingBar: FC<TrackingBarProps> = (props) => {
+  // Gate rendering without using hooks to satisfy react-hooks/rules-of-hooks
+  if (!flags.trackingEnabled) return null;
+  return <TrackingBarInner {...props} />;
 };

--- a/src/app/[lang]/(rastreo)/rastreo/page.tsx
+++ b/src/app/[lang]/(rastreo)/rastreo/page.tsx
@@ -1,7 +1,9 @@
 import { NextPage } from "next";
+import { redirect } from 'next/navigation';
 import { Locale } from "@/i18n.config";
 
 import { config } from '@src/lib/config/env';
+import { flags } from '@src/lib/config/flags';
 
 import { Tracking } from '@rastreo/rastreo/container/Tracking';
 import { ApiResponse, DataTracking } from '@rastreo/rastreo/interfaces/tracking';
@@ -12,6 +14,9 @@ interface TrackingPageProps {
 }
 
 const TrackingPage: NextPage<TrackingPageProps> = async ({ params, searchParams }) => {
+  if (!flags.trackingEnabled) {
+    return redirect(`/${params.lang}`);
+  }
   const trackingId = searchParams['tracking-id'];
 
   if (!trackingId || typeof trackingId !== 'string' || trackingId.trim() === '') {

--- a/src/app/[lang]/(rastreo)/tracking/page.tsx
+++ b/src/app/[lang]/(rastreo)/tracking/page.tsx
@@ -1,7 +1,9 @@
 import { NextPage } from "next";
+import { redirect } from 'next/navigation';
 import { Locale } from "@/i18n.config";
 
 import { config } from '@src/lib/config/env';
+import { flags } from '@src/lib/config/flags';
 
 import { Tracking } from '@rastreo/rastreo/container/Tracking';
 import { ApiResponse, DataTracking } from '@rastreo/rastreo/interfaces/tracking';
@@ -12,6 +14,9 @@ interface TrackingPageProps {
 }
 
 const TrackingPage: NextPage<TrackingPageProps> = async ({ params, searchParams }) => {
+  if (!flags.trackingEnabled) {
+    return redirect(`/${params.lang}`);
+  }
   const trackingId = searchParams['tracking-id'];
 
   if (!trackingId || typeof trackingId !== 'string' || trackingId.trim() === '') {

--- a/src/app/hooks/useTracking.ts
+++ b/src/app/hooks/useTracking.ts
@@ -1,4 +1,5 @@
 import { gtmEvents } from "@/src/lib/gtm";
+import { flags } from "@src/lib/config/flags";
 
 export const useTracking = ({
   lang,
@@ -16,23 +17,32 @@ export const useTracking = ({
     trackingType: string;
     origin: string;
   }) => {
+    if (!flags.trackingEnabled) return;
+
+    let didAction = false;
     switch (trackingType) {
       case "packaging":
         handleTrackingPackaging(trackingNumber);
+        didAction = true;
         break;
       case "messaging":
-        handleTrackingMessaging(trackingNumber);
+        if (flags.messagingTrackingEnabled) {
+          handleTrackingMessaging(trackingNumber);
+          didAction = true;
+        }
         break;
       default:
         break;
     }
 
-    gtmEvents({
-      event: `clic_rastreo_${origin}`,
-      action: "clic-event",
-      category: "clic",
-      label: "rastreo",
-    });
+    if (didAction) {
+      gtmEvents({
+        event: `clic_rastreo_${origin}`,
+        action: "clic-event",
+        category: "clic",
+        label: "rastreo",
+      });
+    }
   };
 
   const handleTrackingPackaging = (trackingNumber: string) => {

--- a/src/app/ui/components/StickyTracking/index.tsx
+++ b/src/app/ui/components/StickyTracking/index.tsx
@@ -5,6 +5,7 @@ import { Close, StickyTrackEs, StickyTrackEn, ArrowCta } from '@icons/index';
 
 import useObserverTracking from '@ui/components/StickyTracking/hooks/useObserverTracking';
 import { useTracking, useForm } from '@/src/app/hooks/';
+import { flags } from '@src/lib/config/flags';
 
 interface StickyTrackingProps {
   observerActive?: boolean;
@@ -12,13 +13,11 @@ interface StickyTrackingProps {
   samePage?: boolean;
 }
 
-const StickyTracking: FC<StickyTrackingProps> = ({
+const StickyTrackingInner: FC<StickyTrackingProps> = ({
   observerActive = false,
   lang = 'es',
   samePage = false,
 }) => {
-  const enableTracking = process.env.NEXT_PUBLIC_ENABLED_MESSAGING_TRACKING;
-
   const [showTrackingIcon, showTrackingForm, showTrackingFormHandler] =
     useObserverTracking(observerActive);
 
@@ -99,7 +98,7 @@ const StickyTracking: FC<StickyTrackingProps> = ({
                       <option value="packaging">
                         {lang === 'es' ? 'Paquetería' : 'Courier'}
                       </option>
-                      {enableTracking === 'true' && (
+                      {flags.messagingTrackingEnabled && (
                         <option value="messaging">
                           {lang === 'es' ? 'Mensajería' : 'Messaging'}
                         </option>
@@ -145,6 +144,12 @@ const StickyTracking: FC<StickyTrackingProps> = ({
       )}
     </>
   );
+};
+
+const StickyTracking: FC<StickyTrackingProps> = (props) => {
+  // Gate rendering without using hooks to satisfy react-hooks/rules-of-hooks
+  if (!flags.trackingEnabled) return null;
+  return <StickyTrackingInner {...props} />;
 };
 
 export default StickyTracking;

--- a/src/lib/config/flags.ts
+++ b/src/lib/config/flags.ts
@@ -1,0 +1,20 @@
+type FeatureFlags = {
+  trackingEnabled: boolean;
+  messagingTrackingEnabled: boolean;
+};
+
+const parseBoolean = (raw: any, defaultValue = false): boolean => {
+  if (raw === undefined) return defaultValue;
+  return String(raw).toLowerCase() === 'true';
+};
+
+// IMPORTANT: Usar accesos estáticos a process.env.NEXT_PUBLIC_* para permitir inlining en el cliente
+const RAW_ENABLED_TRACKING = process.env.NEXT_PUBLIC_ENABLED_TRACKING;
+const RAW_ENABLED_MESSAGING_TRACKING = process.env.NEXT_PUBLIC_ENABLED_MESSAGING_TRACKING;
+
+export const flags: FeatureFlags = {
+  // Controla toda la funcionalidad de rastreo (secciones, componentes y páginas)
+  trackingEnabled: parseBoolean(RAW_ENABLED_TRACKING, true),
+  // Control específico para la opción de "Mensajería" dentro del rastreo
+  messagingTrackingEnabled: parseBoolean(RAW_ENABLED_MESSAGING_TRACKING, false),
+};


### PR DESCRIPTION
This pull request introduces a feature flag system to control the visibility and behavior of tracking-related functionality across the application. The main goal is to centralize the management of tracking features (including the "messaging" tracking option) and ensure that components and pages respond consistently to environment configuration. The changes replace direct environment variable checks with a new `flags` object, and update gating logic for rendering and event handling accordingly.

Feature flag system implementation:

* Added a new `flags` object in `src/lib/config/flags.ts` to centralize and standardize access to tracking-related feature flags, parsing environment variables for `trackingEnabled` and `messagingTrackingEnabled`.

Component and UI gating:

* Updated `TrackingBar` (`src/app/[lang]/(inicio)/sections/TrackingBar/index.tsx`) and `StickyTracking` (`src/app/ui/components/StickyTracking/index.tsx`) components to use the new `flags` object for gating rendering and controlling the visibility of the "messaging" tracking option, replacing previous direct environment variable checks. ([src/app/[lang]/(inicio)/sections/TrackingBar/index.tsxR6-L20](diffhunk://#diff-04010e24822a02043378a38b7c3c4f7136285d6beaaf655328fc29658d6695a6R6-L20), [src/app/[lang]/(inicio)/sections/TrackingBar/index.tsxL75-R74](diffhunk://#diff-04010e24822a02043378a38b7c3c4f7136285d6beaaf655328fc29658d6695a6L75-R74), [src/app/[lang]/(inicio)/sections/TrackingBar/index.tsxR111-R116](diffhunk://#diff-04010e24822a02043378a38b7c3c4f7136285d6beaaf655328fc29658d6695a6R111-R116), [[1]](diffhunk://#diff-42fc33a6e9ebce117641a0788c358ccbfe0f520d3e95361eeb5cfad3b4a964b5R8-L21) [[2]](diffhunk://#diff-42fc33a6e9ebce117641a0788c358ccbfe0f520d3e95361eeb5cfad3b4a964b5L102-R101) [[3]](diffhunk://#diff-42fc33a6e9ebce117641a0788c358ccbfe0f520d3e95361eeb5cfad3b4a964b5R149-R154)

Page-level access control:

* Updated tracking pages (`src/app/[lang]/(rastreo)/rastreo/page.tsx` and `src/app/[lang]/(rastreo)/tracking/page.tsx`) to redirect to the home page if tracking is disabled via feature flag, ensuring users cannot access tracking functionality when it's turned off. ([src/app/[lang]/(rastreo)/rastreo/page.tsxR2-R6](diffhunk://#diff-c15268e9222bfbdccdcda84eb19419bd95e83fde4979a91468685e6e5ae04bbdR2-R6), [src/app/[lang]/(rastreo)/rastreo/page.tsxR17-R19](diffhunk://#diff-c15268e9222bfbdccdcda84eb19419bd95e83fde4979a91468685e6e5ae04bbdR17-R19))

Behavioral adjustments:

* Updated the `useTracking` hook to respect the new feature flags, preventing tracking actions and analytics events when tracking is disabled, and ensuring the "messaging" tracking action only fires if enabled. [[1]](diffhunk://#diff-361cba1f7adbd3021d7236180853f32d524e1c450418477519cd4db1b302988dR2) [[2]](diffhunk://#diff-361cba1f7adbd3021d7236180853f32d524e1c450418477519cd4db1b302988dR20-R45)